### PR TITLE
feat: add run evaluation tool (WIP)

### DIFF
--- a/src/circleci-tools.ts
+++ b/src/circleci-tools.ts
@@ -17,6 +17,8 @@ import { runPipeline } from './tools/runPipeline/handler.js';
 import { runPipelineTool } from './tools/runPipeline/tool.js';
 import { listFollowedProjectsTool } from './tools/listFollowedProjects/tool.js';
 import { listFollowedProjects } from './tools/listFollowedProjects/handler.js';
+import { runEvaluationTestsTool } from './tools/runEvaluationTests/tool.js';
+import { runEvaluationTests } from './tools/runEvaluationTests/handler.js';
 
 // Define the tools with their configurations
 export const CCI_TOOLS = [
@@ -29,6 +31,7 @@ export const CCI_TOOLS = [
   recommendPromptTemplateTestsTool,
   runPipelineTool,
   listFollowedProjectsTool,
+  runEvaluationTestsTool,
 ];
 
 // Extract the tool names as a union type
@@ -53,4 +56,5 @@ export const CCI_HANDLERS = {
   recommend_prompt_template_tests: recommendPromptTemplateTests,
   run_pipeline: runPipeline,
   list_followed_projects: listFollowedProjects,
+  run_evaluation_tests: runEvaluationTests,
 } satisfies ToolHandlers;

--- a/src/clients/circleci/pipelines.ts
+++ b/src/clients/circleci/pipelines.ts
@@ -138,10 +138,12 @@ export class PipelinesAPI {
     projectSlug,
     branch,
     definitionId,
+    configContent = '',
   }: {
     projectSlug: string;
     branch: string;
     definitionId: string;
+    configContent?: string;
   }): Promise<RunPipelineResponse> {
     const rawResult = await this.client.post<unknown>(
       `/project/${projectSlug}/pipeline/run`,
@@ -149,6 +151,7 @@ export class PipelinesAPI {
         definition_id: definitionId,
         config: {
           branch,
+          content: configContent,
         },
         checkout: {
           branch,

--- a/src/tools/runEvaluationTests/handler.test.ts
+++ b/src/tools/runEvaluationTests/handler.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { run-evaluation-tests } from './handler.js';
+
+describe('run-evaluation-tests', () => {
+  it('should return the message provided by the user', async () => {
+    const controller = new AbortController();
+    const result = await run-evaluation-tests(
+      {
+        params: {
+          message: 'Hello, world!',
+        },
+      },
+      {
+        signal: controller.signal,
+      }
+    );
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: 'Received message: Hello, world!',
+        },
+      ],
+    });
+  });
+});

--- a/src/tools/runEvaluationTests/handler.ts
+++ b/src/tools/runEvaluationTests/handler.ts
@@ -1,0 +1,49 @@
+import { ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
+import fs from 'fs';
+import { runEvaluationTestsInputSchema } from './inputSchema.js';
+import mcpErrorOutput from '../../lib/mcpErrorOutput.js';
+
+export const runEvaluationTests: ToolCallback<{
+  params: typeof runEvaluationTestsInputSchema;
+}> = async (args) => {
+  const { projectSlug, tests } = args.params;
+
+  if (!tests) {
+    return mcpErrorOutput('Missing required input: tests');
+  }
+
+  if (!projectSlug) {
+    return mcpErrorOutput('Missing required input: projectSlug');
+  }
+
+  fs.writeFileSync('tests.json', JSON.stringify(tests, null, 2));
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: `Received projectSlug: ${projectSlug}
+
+NEXT STEP:
+- Run a pipeline with the following configuration:
+\`\`\`
+version: 2.1
+
+jobs:
+  hello-job:
+    docker:
+      - image: cimg/node:17.2.0 # the primary container, where your job's commands are run
+    steps:
+      - checkout # check out the code in the project directory
+      - run: echo "hello world" # run the 'echo' command
+
+workflows:
+  my-workflow-from-mcp:
+    jobs:
+      - hello-job
+\`\`\`
+`,
+      },
+    ],
+  };
+};

--- a/src/tools/runEvaluationTests/inputSchema.ts
+++ b/src/tools/runEvaluationTests/inputSchema.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+export const runEvaluationTestsInputSchema = z.object({
+  projectSlug: z
+    .string()
+    .describe(
+      'The project slug obtained from listFollowedProjects tool (e.g., "gh/organization/project").',
+    ),
+  tests: z
+    .array(
+      z.object({
+        name: z.string(),
+        description: z.string(),
+      }),
+    )
+    .describe('Array of tests to run on the project'),
+  sampleInputs: z
+    .array(z.record(z.string(), z.string()))
+    .describe('Array of sample inputs for the prompt template'),
+});

--- a/src/tools/runEvaluationTests/tool.ts
+++ b/src/tools/runEvaluationTests/tool.ts
@@ -1,0 +1,45 @@
+import { runEvaluationTestsInputSchema } from './inputSchema.js';
+
+export const runEvaluationTestsTool = {
+  name: 'run_evaluation_tests' as const,
+  description: `
+  This tool allows the users to run evaluation tests on a circleci pipeline.
+  They can be referred to as "Prompt Tests" or "Evaluation Tests".
+
+  About this tool:
+  - This tool is part of a tool chain that runs evaluation tests on a circleci pipeline.
+  - The tool will generate the appropriate circleci configuration file and trigger a pipeline using this temporary configuration.
+  - The tool will return the project slug.
+
+  Parameters:
+  - params: An object containing:
+    - template: string - The prompt template to be tested
+    - projectSlug: string - The project slug obtained from listFollowedProjects tool (e.g., "gh/organization/project")
+    - tests: Array of objects - The array of tests to run on the project
+    - sampleInputs: Array of objects - The array of sample inputs for the prompt template
+
+  Example usage:
+  {
+    "params": {
+      "template": "The user wants a bedtime story about {{topic}} for a person of age {{age}} years old. Please craft a captivating tale that captivates their imagination and provides a delightful bedtime experience.",
+      "projectSlug": "gh/organization/project",
+      "tests": [
+        {
+          "name": "Test 1",
+          "description": "Description of test 1"
+        }
+      ],
+      "sampleInputs": [
+        {
+          "topic": "unicorns",
+          "age": "6"
+        }
+      ]
+    }
+  }
+
+  Returns:
+  - the project slug
+  `,
+  inputSchema: runEvaluationTestsInputSchema,
+};

--- a/src/tools/runPipeline/handler.ts
+++ b/src/tools/runPipeline/handler.ts
@@ -15,6 +15,7 @@ export const runPipeline: ToolCallback<{
     workspaceRoot,
     gitRemoteURL,
     branch,
+    configContent,
     projectURL,
     pipelineChoiceName,
     projectSlug: inputProjectSlug,
@@ -115,6 +116,7 @@ export const runPipeline: ToolCallback<{
     projectSlug,
     branch: foundBranch,
     definitionId: runPipelineDefinitionId,
+    configContent,
   });
 
   return {

--- a/src/tools/runPipeline/inputSchema.ts
+++ b/src/tools/runPipeline/inputSchema.ts
@@ -40,4 +40,10 @@ export const runPipelineInputSchema = z.object({
         'If provided, it must exactly match one of the pipeline names returned by the tool.',
     )
     .optional(),
+  configContent: z
+    .string()
+    .describe(
+      'The content of the CircleCI YAML configuration file for the pipeline.',
+    )
+    .optional(),
 });

--- a/src/tools/runPipeline/tool.ts
+++ b/src/tools/runPipeline/tool.ts
@@ -22,6 +22,9 @@ export const runPipelineTool = {
     - gitRemoteURL: The URL of the git remote repository
     - branch: The name of the current branch
 
+    Configuration:
+    - an optional configContent parameter can be provided to override the default pipeline configuration
+
     Pipeline Selection:
     - If the project has multiple pipeline definitions, the tool will return a list of available pipelines
     - You must then make another call with the chosen pipeline name using the pipelineChoiceName parameter


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added a new tool to run evaluation tests on CircleCI pipelines, allowing users to define tests and sample inputs, and updated pipeline tools to support custom configuration content.

- **New Features**
  - Added runEvaluationTests tool with input schema and handler.
  - Allows passing custom CircleCI config content when running pipelines.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new tool for running evaluation tests on CircleCI pipelines, allowing users to define tests and sample inputs for prompt templates.
  - Added support for providing custom CircleCI YAML configuration content when triggering pipeline runs.

- **Bug Fixes**
  - Not applicable.

- **Documentation**
  - Updated tool descriptions and input options to reflect new configuration capabilities.

- **Tests**
  - Added tests to verify the new evaluation tests tool handler.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->